### PR TITLE
disable source maps in prod

### DIFF
--- a/packages/react-app/package.json
+++ b/packages/react-app/package.json
@@ -94,7 +94,7 @@
     "extends": "react-app"
   },
   "scripts": {
-    "build": "craco build",
+    "build": "GENERATE_SOURCEMAP=false craco build",
     "eject": "craco eject",
     "prestart": "node ./scripts/create_contracts.js",
     "start": "craco start",


### PR DESCRIPTION
Disable sourcemaps in production mode by default to reduce bundle size and make deployment faster.
Can be enabled for debugging production bugs if needed