### PR TITLE
Make Parcel Viewer responsive for small screens

### DIFF
--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -14,7 +14,7 @@ function App() {
   dispatch(setDebugMode(process.env.REACT_APP_DEBUG));
   return (
     <div className="App text-center">
-      <Layout style={{ height: "100vh", display: "flex" }}>
+      <Layout className="app-layout">
         <Web3Wrapper />
       </Layout>
       <ToastContainer />

--- a/packages/react-app/src/App.less
+++ b/packages/react-app/src/App.less
@@ -23,6 +23,7 @@
   height: 2px;
   margin: 0;
 }
+
 .sidebar {
   width: 400px;
 }
@@ -125,6 +126,14 @@
 .connect-wallet {
   background-color: @primary;
 }
+.connect-wallet-button {
+  font-size: 16px;
+
+  @media (max-width: 1024px) {
+    font-size: 12px;
+    margin-right: 0.75rem;
+  }
+}
 .connected {
   background-color: transparent;
   border: 1px solid @primary;
@@ -147,9 +156,6 @@
 .logo-display {
   border-color: @gray-4;
 }
-.header {
-  border-color: @gray-4;
-}
 
 /* search bar styles */
 input:focus,
@@ -162,6 +168,10 @@ select:focus {
   * {
     border-color: @gray-4;
     background-color: transparent;
+  }
+
+  @media (max-width: 720px) {
+    width: 55%;
   }
 }
 
@@ -211,4 +221,82 @@ select:focus {
   border-left: 10px @gray-2 solid;
   border-top: 10px @gray-2 solid;
   border-bottom: 10px @gray-2 solid;
+}
+
+/* BrowsePlots Layout */
+.progress-bar-indicator {
+  @media (max-width: 475px) {
+    margin-left: 0;
+  }
+}
+
+.ant-tabs-content-holder {
+  overflow-y: scroll;
+  margin-bottom: 0.75rem;
+}
+
+.search-plots-input {
+  @media (max-width: 400px) {
+    max-width: 85%;
+  }
+}
+
+.browse-plots-wrapper {
+  height: 100%;
+  display: grid;
+  grid-template-columns: 400px 1fr;
+  grid-template-rows: 3rem 4rem 1fr;
+  grid-column-gap: 0px;
+  grid-row-gap: 0px;
+
+  @media (max-width: 1024px) {
+    grid-template-columns: 1fr;
+    grid-template-rows: 3rem repeat(2, 4rem) 300px 4rem 5fr;
+  }
+}
+
+.progress-bar {
+  grid-area: 1 / 1 / 2 / 3;
+}
+.logo-link {
+  grid-area: 2 / 1 / 3 / 2;
+}
+.connect-wallet-section {
+  grid-area: 2 / 2 / 3 / 3;
+  border-color: @gray-4;
+  justify-content: flex-end;
+}
+.plot-detail {
+  grid-area: 3 / 1 / 4 / 2;
+}
+.plot-tabs {
+  grid-area: 3 / 1 / 4 / 2;
+  width: 100%;
+}
+.plot-map {
+  grid-area: 3 / 2 / 4 / 3;
+}
+
+@media (max-width: 1024px) {
+  .progress-bar {
+    grid-area: 1 / 1 / 2 / 2;
+  }
+  .logo-link {
+    grid-area: 2 / 1 / 3 / 2;
+  }
+  .connect-wallet-section {
+    grid-area: 3 / 1 / 4 / 2;
+    justify-content: center;
+    max-width: 100vw;
+  }
+  .plot-map {
+    grid-area: 4 / 1 / 5 / 2;
+  }
+  .plot-tabs {
+    grid-area: 5 / 1 / 7 / 2;
+    max-width: 100vw;
+  }
+  .plot-detail {
+    grid-area: 6 / 1 / 7 / 2;
+  }
 }

--- a/packages/react-app/src/App.less
+++ b/packages/react-app/src/App.less
@@ -109,6 +109,7 @@
   @media (max-width: 720px) {
     overflow-y: scroll;
     height: auto;
+    background-color: @gray-2;
   }
 }
 
@@ -242,6 +243,18 @@ select:focus {
   border-left: 10px @gray-2 solid;
   border-top: 10px @gray-2 solid;
   border-bottom: 10px @gray-2 solid;
+}
+
+/* Plot Detail */
+.plot-detail-content {
+  overflow-y: scroll;
+  max-height: 75vh;
+
+  @media (max-width: 1024px) {
+    overflow-y: initial;
+    padding-bottom: 2rem;
+    max-height: initial;
+  }
 }
 
 /* BrowsePlots Layout */

--- a/packages/react-app/src/App.less
+++ b/packages/react-app/src/App.less
@@ -99,6 +99,19 @@
   background: @primary;
 }
 
+/* App */
+.app-layout {
+  display: flex;
+  min-height: 100vh;
+  height: 100vh;
+  overflow-y: initial;
+
+  @media (max-width: 720px) {
+    overflow-y: scroll;
+    height: auto;
+  }
+}
+
 /* List styles */
 .list {
   .list-item {
@@ -216,6 +229,10 @@ select:focus {
 ::-webkit-scrollbar {
   width: 15px;
   left: -100px !important;
+
+  @media (max-width: 720px) {
+    width: 0;
+  }
 }
 
 /* Handle */
@@ -243,6 +260,10 @@ select:focus {
 .ant-tabs-content-holder {
   overflow-y: scroll;
   margin-bottom: 0.75rem;
+
+  @media (max-width: 720px) {
+    overflow-y: initial;
+  }
 }
 
 .search-plots-input {

--- a/packages/react-app/src/App.less
+++ b/packages/react-app/src/App.less
@@ -171,7 +171,11 @@ select:focus {
   }
 
   @media (max-width: 720px) {
-    width: 55%;
+    width: 35%;
+  }
+
+  @media (max-width: 450px) {
+    width: 50%;
   }
 }
 
@@ -225,7 +229,13 @@ select:focus {
 
 /* BrowsePlots Layout */
 .progress-bar-indicator {
+  margin-left: 3rem;
+
   @media (max-width: 475px) {
+    margin-left: 2rem;
+  }
+
+  @media (max-width: 425px) {
     margin-left: 0;
   }
 }
@@ -236,7 +246,9 @@ select:focus {
 }
 
 .search-plots-input {
-  @media (max-width: 400px) {
+  width: 100%;
+
+  @media (max-width: 500px) {
     max-width: 85%;
   }
 }
@@ -252,6 +264,11 @@ select:focus {
   @media (max-width: 1024px) {
     grid-template-columns: 1fr;
     grid-template-rows: 3rem repeat(2, 4rem) 300px 4rem 5fr;
+  }
+
+  // Responsive for mobile landscape screens
+  @media (max-height: 500px) {
+    grid-template-rows: 3rem repeat(2, 4rem) 300px 4rem 600px;
   }
 }
 

--- a/packages/react-app/src/components/ConnectWalletButton.tsx
+++ b/packages/react-app/src/components/ConnectWalletButton.tsx
@@ -14,7 +14,7 @@ export default function ConnectWalletButton({ onClick }: Props) {
         onClick={onClick}
         className={`connect-wallet-button ${
           userAddress ? "connected" : "connect-wallet"
-        } secondary-font text-lg px-4 h-9 rounded`}
+        } secondary-font px-4 h-9 rounded`}
       >
         {userAddress ? userAddress?.slice(0, 6) + "..." + userAddress?.slice(-5, -1) : "Connect Wallet"}
       </button>

--- a/packages/react-app/src/components/EnterRaffle.tsx
+++ b/packages/react-app/src/components/EnterRaffle.tsx
@@ -51,7 +51,7 @@ export default function EnterRaffle({ injectedProvider, inRaffle, resetStatus }:
     <Tooltip title={userAddress && !inRaffle ? null : tooltip}>
       <button
         onClick={() => userAddress && !inRaffle && raffleRules()}
-        className={`connect-wallet-button connect-wallet secondary-font text-lg px-4 h-9 rounded ${
+        className={`connect-wallet-button connect-wallet secondary-font px-4 h-9 rounded ${
           !userAddress || inRaffle ? "opacity-50" : ""
         } flex items-center justify-center`}
       >

--- a/packages/react-app/src/components/Header.tsx
+++ b/packages/react-app/src/components/Header.tsx
@@ -6,7 +6,7 @@ interface Props {
 }
 export default function Header({ connectWallet }: Props) {
   return (
-    <div className="header primary-font text-xl bg-gray-1 flex h-16 px-4 border-l-2 border-b-2 items-center justify-end">
+    <div className="connect-wallet-section header primary-font text-xl bg-gray-1 flex h-16 lg:px-4 border-l-2 border-b-2 items-center">
       <SearchPlots />
       <ConnectWalletButton onClick={connectWallet} />
     </div>

--- a/packages/react-app/src/components/PlotDetail.tsx
+++ b/packages/react-app/src/components/PlotDetail.tsx
@@ -50,7 +50,7 @@ export default function PlotDetail({ plot, contracts, injectedProvider }: Props)
         </div>
         <Divider />
 
-        <div className="block overflow-y-scroll p-4" style={{ maxHeight: "75vh" }}>
+        <div className="plot-detail-content block p-4">
           <div className="flex flex-col space-y-4 primary-font text-lg">
             <motion.img
               src={plotMetadata?.image ?? LAND_IMG}

--- a/packages/react-app/src/components/PlotList.tsx
+++ b/packages/react-app/src/components/PlotList.tsx
@@ -27,7 +27,7 @@ export default function PlotList({ plots, emptyMessage }: Props) {
   };
 
   return (
-    <div className="list block overflow-y-scroll" style={{ maxHeight: "80vh" }}>
+    <div className="list block">
       {displayedPlots.map((plot: Plot, idx: number) => (
         <motion.div className="list-item" key={plot.id} layout>
           {/* modulo delay by 10 because plot buttons are added in batches of 10 */}

--- a/packages/react-app/src/components/PlotMap.jsx
+++ b/packages/react-app/src/components/PlotMap.jsx
@@ -110,7 +110,7 @@ export default function PlotMap({ parcel, plots, startingCoordinates, startingZo
   }, [highlightedPlot, map.current]);
 
   return (
-    <div className="flex-grow flex flex-col relative">
+    <div className="plot-map flex-grow flex flex-col relative">
       <AnimatePresence>{!mapLoaded && <Loading />}</AnimatePresence>
       <div ref={mapContainer} className="absolute left-0 right-0 top-0 bottom-0 plot-map" />
     </div>
@@ -122,7 +122,7 @@ function Loading() {
     <motion.div
       initial={{ opacity: 1 }}
       exit={{ opacity: 0 }}
-      className="bg-black absolute left-0 right-0 top-0 bottom-0 z-10 flex items-center justify-center"
+      className="plot-map bg-black absolute left-0 right-0 top-0 bottom-0 z-10 flex items-center justify-center"
     >
       <img src={loading} alt="loading" />
     </motion.div>

--- a/packages/react-app/src/components/PlotTabs.tsx
+++ b/packages/react-app/src/components/PlotTabs.tsx
@@ -17,7 +17,7 @@ export default function PlotTabs() {
   });
 
   return (
-    <Tabs defaultActiveKey="1" className="px-4 w-full">
+    <Tabs defaultActiveKey="1" className="plot-tabs px-4">
       <TabPane tab="Available" key="1">
         <PlotList
           plots={plots.filter(plot => !plot.sold)}

--- a/packages/react-app/src/components/ProgressBar.tsx
+++ b/packages/react-app/src/components/ProgressBar.tsx
@@ -5,11 +5,11 @@ export default function ProgressBar() {
   const plots = useAppSelector(state => state.plots.plots);
   const percent_sold = Math.ceil((plots.filter(plot => plot.sold).length / plots.length) * 100);
   return (
-    <div className="progress-bar header w-full bg-gradient h-12 py-4 z-10 text-gray-1 flex items-center justify-center text-base primary-font font-semibold">
+    <div className="progress-bar header w-full bg-gradient h-12 py-4 px-2 z-10 text-gray-1 flex items-center justify-center text-base primary-font font-semibold">
       {plots.length > 0 && (percent_sold < 100 ? "Parcel 0 sale is live!" : "Parcel 0 sale is sold out!")}
       {plots.length === 0 && "Fetching plots..."}
       {percent_sold < 100 ? (
-        <div className="progress-bar-indicator ml-12 bg-transparent flex text-gray-1 items-center text-sm font-normal secondary-font">
+        <div className="progress-bar-indicator bg-transparent flex text-gray-1 items-center text-sm font-normal secondary-font">
           <div className="progress-bar w-40 bg-gray-9 rounded-full h-2 mx-2">
             <div className="progress-bar-fill bg-primary-4 rounded-full h-full" style={{ width: `${percent_sold}%` }} />
           </div>

--- a/packages/react-app/src/components/ProgressBar.tsx
+++ b/packages/react-app/src/components/ProgressBar.tsx
@@ -5,11 +5,11 @@ export default function ProgressBar() {
   const plots = useAppSelector(state => state.plots.plots);
   const percent_sold = Math.ceil((plots.filter(plot => plot.sold).length / plots.length) * 100);
   return (
-    <div className="header w-full bg-gradient h-12 py-4 z-10 text-gray-1 flex items-center justify-center text-base primary-font font-semibold">
+    <div className="progress-bar header w-full bg-gradient h-12 py-4 z-10 text-gray-1 flex items-center justify-center text-base primary-font font-semibold">
       {plots.length > 0 && (percent_sold < 100 ? "Parcel 0 sale is live!" : "Parcel 0 sale is sold out!")}
       {plots.length === 0 && "Fetching plots..."}
       {percent_sold < 100 ? (
-        <div className="ml-12 bg-transparent flex text-gray-1 items-center text-sm font-normal secondary-font">
+        <div className="progress-bar-indicator ml-12 bg-transparent flex text-gray-1 items-center text-sm font-normal secondary-font">
           <div className="progress-bar w-40 bg-gray-9 rounded-full h-2 mx-2">
             <div className="progress-bar-fill bg-primary-4 rounded-full h-full" style={{ width: `${percent_sold}%` }} />
           </div>

--- a/packages/react-app/src/components/SearchPlots.tsx
+++ b/packages/react-app/src/components/SearchPlots.tsx
@@ -10,7 +10,7 @@ export default function SearchPlots() {
       <input
         type="text"
         placeholder="Search for plot #..."
-        className="bg-transparent h-full px-2 text-gray-7 w-72"
+        className="search-plots-input bg-transparent h-full px-2 text-gray-7 w-72"
         onChange={e => dispatch(setIdFilter(e.target.value))}
       />
       <div className="flex items-center justify-center h-full w-9 bg-transparent border-l">

--- a/packages/react-app/src/components/SearchPlots.tsx
+++ b/packages/react-app/src/components/SearchPlots.tsx
@@ -10,7 +10,7 @@ export default function SearchPlots() {
       <input
         type="text"
         placeholder="Search for plot #..."
-        className="search-plots-input bg-transparent h-full px-2 text-gray-7 w-72"
+        className="search-plots-input bg-transparent h-full px-2 text-gray-7"
         onChange={e => dispatch(setIdFilter(e.target.value))}
       />
       <div className="flex items-center justify-center h-full w-9 bg-transparent border-l">

--- a/packages/react-app/src/views/BrowsePlots.tsx
+++ b/packages/react-app/src/views/BrowsePlots.tsx
@@ -1,6 +1,4 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { Col, Layout } from "antd";
-import { Content } from "antd/lib/layout/layout";
 import { ethers } from "ethers";
 import { Link } from "react-router-dom";
 
@@ -96,6 +94,7 @@ export default function BrowsePlots({ networkProvider, web3Modal }: Props) {
       DEBUG && console.log(e);
     }
   };
+
   useEffect(() => {
     readParcel();
   }, [contracts]);
@@ -110,6 +109,7 @@ export default function BrowsePlots({ networkProvider, web3Modal }: Props) {
       dispatch(setWhitelistedAmount(0));
     }
   };
+
   useEffect(() => {
     readWhitelistStatus();
   }, [contracts, userAddress, plots]);
@@ -122,34 +122,26 @@ export default function BrowsePlots({ networkProvider, web3Modal }: Props) {
   });
 
   return (
-    <>
+    <div className="browse-plots-wrapper">
       <ProgressBar />
-      <div className="flex flex-row flex-grow min-w-0">
-        <Col className="sidebar">
-          <Link to="/whitelist">
-            <LogoDisplay />
-          </Link>
-          {activePlot !== undefined ? (
-            <PlotDetail plot={activePlot} contracts={contracts} injectedProvider={injectedProvider} />
-          ) : (
-            <PlotTabs />
-          )}
-        </Col>
-        <Layout className="site-layout">
-          <Content className="flex flex-col">
-            <Header connectWallet={loadWeb3Modal} />
-            {/* key prop is to cause rerendering whenever it changes */}
-            <PlotMap
-              key={plots.length}
-              parcel={parcel}
-              plots={plots}
-              startingCoordinates={[-109.25689639464197, 44.922331600075466]}
-              startingZoom={15.825123438299038}
-              startingPitch={20}
-            />
-          </Content>
-        </Layout>
-      </div>
-    </>
+      <Link to="/whitelist" className="logo-link">
+        <LogoDisplay />
+      </Link>
+      {activePlot !== undefined ? (
+        <PlotDetail plot={activePlot} contracts={contracts} injectedProvider={injectedProvider} />
+      ) : (
+        <PlotTabs />
+      )}
+      <Header connectWallet={loadWeb3Modal} />
+      {/* key prop is to cause rerendering whenever it changes */}
+      <PlotMap
+        key={plots.length}
+        parcel={parcel}
+        plots={plots}
+        startingCoordinates={[-109.25689639464197, 44.922331600075466]}
+        startingZoom={15.825123438299038}
+        startingPitch={20}
+      />
+    </div>
   );
 }


### PR DESCRIPTION
Made the Parcel Viewer responsive on small mobile screens. I used CSS grid/flexbox/media queries to accomplish.

**Preview - before:** https://citydao-frontend.onrender.com/
**Preview - after:** https://parcel-viewer-responsive.surge.sh/

**Task**: https://app.dework.xyz/citydao/engineering-2?taskId=5ebaca8a-78af-4216-b39c-fab92b1607e6