### PR TITLE
Add command that fix vercep app build

### DIFF
--- a/packages/react-app/package.json
+++ b/packages/react-app/package.json
@@ -97,6 +97,7 @@
   },
   "scripts": {
     "build": "GENERATE_SOURCEMAP=false craco build",
+    "install-with-deps": "yum install libsecret-devel -y && yarn install",
     "eject": "craco eject",
     "prestart": "node ./scripts/create_contracts.js",
     "start": "craco start",


### PR DESCRIPTION
Hi, 
In order to fix the issue with the missing `libsecret `package during the project build, you should use the new command "install-with-deps" for "Install Command" setting in "Build & Development" section of vercel app settings.



<img width="811" alt="Screenshot 2022-06-10 at 11 20 08" src="https://user-images.githubusercontent.com/6987007/173034354-2cad75a5-3428-495a-9e12-a4c5aae12e14.png">

Here is my  working build: https://citydao-project-lwbz5ube1-azpwnz.vercel.app/

